### PR TITLE
Fix typos and misspellings

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 7
-description: How does narrowlink agent work?
+description: How does Narrowlink agent work?
 keywords: [Agent, Gateway, Client, Narrowlink, Narrow, Link, Networking, Internet, Security, Privacy, Open Source, Self-hosted, Tutorial, How-to, Guide, Nat, Firewall, Proxy, Reverse Proxy, Tunnel]
 ---
 

--- a/docs/basic-tutorial/client-setup.md
+++ b/docs/basic-tutorial/client-setup.md
@@ -30,7 +30,7 @@ tokens: # list of tokens
       policies: # list of policies
         - !Any # any type of protocols
           - null # agent name, null means any agent
-          - true # allow or dency this agent
+          - true # allow or deny this agent
 ```
 This token defines that it belongs to the user space with `00000000-0000-0000-0000-000000000001` user id (uid) and client_name_1 as the client name. The token will expire on `1704067200` (Monday, January 1, 2024 0:00:00 GMT). The access control policy allows the client to access all agents[^1]. You can change these values to your desired values. The user space is used to isolate agents and clients; therefore, each user must have a unique uid. Also, each client must have a unique name.
 

--- a/docs/extended-tutorial/access-control.md
+++ b/docs/extended-tutorial/access-control.md
@@ -21,7 +21,7 @@ To utilize access control, you need to configure policies for your clients. In t
       policies: # list of policies
         - !Any # any type of protocols
           - null # agent name, null means any agent
-          - true # allow or dency this agent
+          - true # allow or deny this agent
 ```
 
 You can set the value of `permit` to false if you want to use blacklisting mode. Setting it to true represents whitelisting.

--- a/docs/extended-tutorial/ssh-integration.md
+++ b/docs/extended-tutorial/ssh-integration.md
@@ -6,9 +6,9 @@ keywords: [SSH, Integration, Gateway, Agent, Client, Narrowlink, Narrow, Link, N
 
 # SSH Integration
 
-The Narrowlink client can acts like `netcat` command to connect to the services that are running on the agent network machine. It is useful for various porpurses such as connecting to a ssh server.
+The Narrowlink client can acts like `netcat` command to connect to the services that are running on the agent network machine. It is useful for various purposes such as connecting to a ssh server.
 
-Add the bellow setting to your ssh client configuration which is normally at `~/.ssh/config` to use narrowlink to conenct to your machines:
+Add the setting below to your ssh client configuration, which typically resides at `~/.ssh/config`, to use Narrowlink to connect to your machines:
 
 ```bash
 Host <agent_name>

--- a/docs/extended-tutorial/vpn-integration.md
+++ b/docs/extended-tutorial/vpn-integration.md
@@ -6,7 +6,7 @@ keywords: [VPN, Integration, Gateway, Agent, Client, Narrowlink, Narrow, Link, N
 
 # VPN Integration
 
-You can integrate NarrowLink with [sing-box](https://github.com/SagerNet/sing-box) to access to the shared network globally on your machine. Altough it is not considered as actual VPN, however it is a good solution for accessing to the shared network globally.
+You can integrate NarrowLink with [sing-box](https://github.com/SagerNet/sing-box) to access to the shared network globally on your machine. Although it is not considered as actual VPN, however it is a good solution for accessing to the shared network globally.
 
 To integrate NarrowLink with sing-box, you need to install sing-box on your machine and then configure it to use NarrowLink as its network provider. Then you need to run the NarrowLink client on your machine as a local SOCKS proxy server.
 

--- a/docs/extended-tutorial/webserver-publish.md
+++ b/docs/extended-tutorial/webserver-publish.md
@@ -42,7 +42,7 @@ tokens: # list of tokens
 The `uid` and `name` fields must be the same as the `uid` and `name` in the agent token. Once a request is received from the gateway, it automatically inserts the `NL-Connecting-IP` header to the request. This header contains the IP address of the client. You can use this header to detect the IP address of the client.
 
 :::tip
-You can use a wildcard in the domain name to publish multiple services without reconfiguring the DNS server every time. For example, you can use `*.domain.example` to publish all subdomains of 
+You can use a wildcard in the domain name to publish multiple services without reconfiguring the DNS server every time. For example, you can use `*.domain.example` to publish all subdomains of
 `domain.example`.
 :::
 
@@ -50,7 +50,7 @@ After generating the publish token, you need to add the token to the agent confi
 
 ```yaml
 #...
-publish: eyJ0eX....kNHYQ_4 # publish token to configurre the agent to publish web services
+publish: eyJ0eX....kNHYQ_4 # publish token to configure the agent to publish web services
 #...
 ```
 

--- a/docs/token-generator.md
+++ b/docs/token-generator.md
@@ -36,10 +36,10 @@ These configuration files are structured in YAML format. Comprehensive examples 
           - TCP # protocol
         - !Any # any type of protocols
           - agent_name_3 # agent name, null means any agent
-          - true # allow or dency this agent
+          - true # allow or deny this agent
         - !Any # any type of protocols
           - agent_name_4 # agent name, null means any agent
-          - true # allow or dency this agent
+          - true # allow or deny this agent
 ```
 
 ## Agent Token
@@ -87,7 +87,7 @@ tokens: # list of tokens
       policies: # list of policies
         - !Any # any type of protocols
           - null # agent name, null means any agent
-          - true # allow or dency this agent
+          - true # allow or deny this agent
 
   - !Client # client token
     uid: 00000000-0000-0000-0000-000000000000 # client uid, please use a unique uid for each user
@@ -108,10 +108,10 @@ tokens: # list of tokens
           - TCP # protocol
         - !Any # any type of protocols
           - agent_name_3 # agent name, null means any agent
-          - true # allow or dency this agent
+          - true # allow or deny this agent
         - !Any # any type of protocols
           - agent_name_4 # agent name, null means any agent
-          - true # allow or dency this agent
+          - true # allow or deny this agent
 
   - !Agent # agent token
     uid: 00000000-0000-0000-0000-000000000000 # agent uid, please use a unique uid for each user


### PR DESCRIPTION
* Consistently use Narrowlink with a capital when referring to the project.
* Fix a copy-pasted typo dency -> deny
* Slightly reword one sentence in ssh-integration.md for clarity
* A few more small typos